### PR TITLE
lexer: fix bug where name tokens were being incorrectly tagged as key…

### DIFF
--- a/cortecs/lexer/lexer.c
+++ b/cortecs/lexer/lexer.c
@@ -87,13 +87,14 @@ static cortecs_lexer_result_t lex_name(char *text, uint32_t start) {
 
     uint32_t len = end - start;
     cortecs_lexer_tag_t tag;
-    if (strncmp(&text[start], "function", len) == 0) {
+
+    if (len == 8 && strncmp(&text[start], "function", len) == 0) {
         tag = CORTECS_LEXER_TAG_FUNCTION;
-    } else if (strncmp(&text[start], "let", len) == 0) {
+    } else if (len == 3 && strncmp(&text[start], "let", len) == 0) {
         tag = CORTECS_LEXER_TAG_LET;
-    } else if (strncmp(&text[start], "if", len) == 0) {
+    } else if (len == 2 && strncmp(&text[start], "if", len) == 0) {
         tag = CORTECS_LEXER_TAG_IF;
-    } else if (strncmp(&text[start], "return", len) == 0) {
+    } else if (len == 6 && strncmp(&text[start], "return", len) == 0) {
         tag = CORTECS_LEXER_TAG_RETURN;
     } else if (isupper(text[start])) {
         tag = CORTECS_LEXER_TAG_TYPE;

--- a/cortecs/lexer/test/lexer.c
+++ b/cortecs/lexer/test/lexer.c
@@ -80,6 +80,15 @@ void cortecs_lexer_test_if(void) {
     cortecs_lexer_test("asdf if 123", 5, "if", CORTECS_LEXER_TAG_IF);
 }
 
+void cortecs_lexer_test_name_one_char(void) {
+    char str[] = {'_', 0};
+    cortecs_lexer_test(str, 0, str, CORTECS_LEXER_TAG_NAME);
+    for (char c = 'a'; c <= 'z'; c++) {
+        str[0] = c;
+        cortecs_lexer_test(str, 0, str, CORTECS_LEXER_TAG_NAME);
+    }
+}
+
 void cortecs_lexer_test_name(void) {
     for (int i = 0; i < 1000; i++) {
         cortecs_lexer_token_t token = cortecs_lexer_fuzz_name();
@@ -136,6 +145,7 @@ int main() {
     RUN_TEST(cortecs_lexer_test_let);
     RUN_TEST(cortecs_lexer_test_return);
     RUN_TEST(cortecs_lexer_test_if);
+    RUN_TEST(cortecs_lexer_test_name_one_char);
     RUN_TEST(cortecs_lexer_test_name);
     RUN_TEST(cortecs_lexer_test_type);
     RUN_TEST(cortecs_lexer_test_whitespace);


### PR DESCRIPTION
…words

if a token matched the prefix of a keyword, it would incorrectly be tagged as the keyword. Ex. "fun" would be tagged as function keyword. "i" would be tagged as if keyword.