### PR TITLE
repo: override codecov branch name

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -23,3 +23,4 @@ jobs:
           files: "./bazel-out/_coverage/_coverage_report.dat"
           token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)
+          override_branch: main


### PR DESCRIPTION
codecov reports were being uploaded for the trunk-io staging branch. Upload them for main instead