### PR TITLE
lexer: add test for token tag to string.

### DIFF
--- a/cortecs/lexer/test/test.c
+++ b/cortecs/lexer/test/test.c
@@ -166,8 +166,27 @@ void cortecs_lexer_test_multi_token_fuzz(void) {
     free(matrix);
 }
 
+static void lexer_test_tag_string(void) {
+    TEST_ASSERT_EQUAL_MEMORY("name", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_NAME), 5);
+    TEST_ASSERT_EQUAL_MEMORY("type", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_TYPE), 5);
+    TEST_ASSERT_EQUAL_MEMORY("int", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_INT), 4);
+    TEST_ASSERT_EQUAL_MEMORY("bad_int", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_BAD_INT), 8);
+    TEST_ASSERT_EQUAL_MEMORY("float", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_FLOAT), 6);
+    TEST_ASSERT_EQUAL_MEMORY("bad_float", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_BAD_FLOAT), 10);
+    TEST_ASSERT_EQUAL_MEMORY("space", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_SPACE), 6);
+    TEST_ASSERT_EQUAL_MEMORY("new_line", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_NEW_LINE), 9);
+    TEST_ASSERT_EQUAL_MEMORY("function", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_FUNCTION), 9);
+    TEST_ASSERT_EQUAL_MEMORY("let", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_LET), 4);
+    TEST_ASSERT_EQUAL_MEMORY("if", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_IF), 3);
+    TEST_ASSERT_EQUAL_MEMORY("return", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_RETURN), 7);
+    TEST_ASSERT_EQUAL_MEMORY("dot", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_DOT), 4);
+    TEST_ASSERT_EQUAL_MEMORY("invalid", cortecs_lexer_tag_to_string(CORTECS_LEXER_TAG_INVALID), 8);
+    TEST_ASSERT_EQUAL_MEMORY("unknown", cortecs_lexer_tag_to_string((cortecs_lexer_tag_t)-1), 8);
+}
+
 int main() {
     UNITY_BEGIN();
+    RUN_TEST(lexer_test_tag_string);
     RUN_TEST(lexer_test_empty_input);
     RUN_TEST(lexer_test_dot);
     RUN_TEST(cortecs_lexer_test_multi_token_fuzz);

--- a/cortecs/lexer/tokens.c
+++ b/cortecs/lexer/tokens.c
@@ -33,5 +33,5 @@ const char *cortecs_lexer_tag_to_string(cortecs_lexer_tag_t tag) {
         case CORTECS_LEXER_TAG_INVALID:
             return "invalid";
     }
-    assert(false);
+    return "unknown";
 }


### PR DESCRIPTION
Mostly to satisfy codecov.