### PR TITLE
repo: remove unused build files

### DIFF
--- a/source/BUILD
+++ b/source/BUILD
@@ -1,5 +1,0 @@
-filegroup(
-    name = "clang_tidy_config",
-    srcs = [".clang-tidy"],
-    visibility = ["//visibility:public"],
-)

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,0 @@
-filegroup(
-    name = "clang_tidy_config",
-    srcs = [".clang-tidy"],
-    visibility = ["//visibility:public"],
-)


### PR DESCRIPTION
these BUILD files are from the old method of executing clang-tidy in CI and are now unused.