### PR TITLE
lexer: change internal encoding to UTF-8

### DIFF
--- a/source/cortecs/lexer/tokens.h
+++ b/source/cortecs/lexer/tokens.h
@@ -45,7 +45,9 @@ typedef enum {
 typedef struct {
     cortecs_lexer_tag_t tag;
     cortecs_span_t span;
-    UChar *text;
+    // Strings are encoded using utf-8 to support unicode and
+    // maintain compatibility with C/OS api that expect ascii encoding.
+    uint8_t *text;
 } cortecs_lexer_token_t;
 
 const char *cortecs_lexer_tag_to_string(cortecs_lexer_tag_t tag);

--- a/test/cortecs/lexer/test_impls.c
+++ b/test/cortecs/lexer/test_impls.c
@@ -8,17 +8,6 @@
 #include <unicode/utypes.h>
 #include <unity.h>
 
-static bool compare_utext_to_string(const UChar *text, const char *keyword) {
-    for (uint32_t i = 0; keyword[i] != 0; i++) {
-        // ASCII characters are encoded with the same value in utf-32
-        if (text[i] != keyword[i]) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 void cortecs_lexer_test(UText *text, char *gold, cortecs_lexer_tag_t tag) {
     cortecs_lexer_token_t out = cortecs_lexer_next(text);
 
@@ -56,7 +45,7 @@ void cortecs_lexer_test(UText *text, char *gold, cortecs_lexer_tag_t tag) {
     }
     TEST_ASSERT_TRUE(out.tag == tag);
 
-    int isDifferent = compare_utext_to_string(out.text, gold);
+    int isDifferent = strncmp(gold, (const char *)out.text, strlen(gold));
     if (isDifferent) {
         NOOP;
     }


### PR DESCRIPTION
Move from UTF-16 encoded strings to UTF-8 to maintain compatibility with C and OS api that expect ascii encoded strings.