### PR TITLE
lsp: split up parsing functions

### DIFF
--- a/source/lsp/lsp.h
+++ b/source/lsp/lsp.h
@@ -9,6 +9,7 @@
 typedef struct {
     enum {
         LSP_PARSE_SUCCESS,
+        LSP_PARSE_SUCCESS_NOT_FOUND,
         LSP_PARSE_MISSING_REQUIRED_FIELD,
         LSP_PARSE_TYPE_ERROR,
     } tag;


### PR DESCRIPTION
Splitting up the parser into find_field and accept_type allows for expanding the code generator for optional and union fields.