### PR TITLE
common: Update common macros and switch to C11

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-common --copt="-Wall" --copt="-Wextra"
+common --copt="-Wall" --copt="-Wextra" --conlyopt="-std=gnu11"

--- a/source/common/common.h
+++ b/source/common/common.h
@@ -10,9 +10,10 @@
     int CONCAT(NOOP_, __LINE__) = 0; \
     UNUSED(CONCAT(NOOP_, __LINE__));
 
-#define MASK(BITS) (~(UINT64_MAX << BITS))
+#define MASK(BITS, SHIFT) (~(UINT64_MAX << BITS) << SHIFT)
+#define MAX_VALUE(BITS) (~(UINT64_MAX << BITS))
 
 #define COMPILE_TIME_ASSERT(predicate) \
-    static char CONCAT(compile_time_assertion_, line)[!!(predicate)-1];
+    static char CONCAT(compile_time_assertion_, __LINE__)[!!(predicate)-1];
 
 #endif


### PR DESCRIPTION
Couple small changes and bugfixes to the common macros. As well, switch to c11 for atomics