### PR TITLE
gc: update gc API to improve usage and fix bug

### DIFF
--- a/source/cortecs/array/public-headers/cortecs/array.h
+++ b/source/cortecs/array/public-headers/cortecs/array.h
@@ -4,13 +4,19 @@
 #include <common.h>
 #include <stdint.h>
 
-#define cortecs_array_forward_declare(TYPE) \
-    typedef struct CONCAT(cortecs_array_, TYPE) CONCAT(cortecs_array_, TYPE)
+#define cortecs_array_name(TYPE) \
+    CONCAT(cortecs_array_, TYPE)
 
-#define cortecs_array_define(TYPE)        \
-    struct CONCAT(cortecs_array_, TYPE) { \
-        uint32_t size;                    \
-        TYPE elements[];                  \
+#define cortecs_pointer_array_name(TYPE) \
+    CONCAT(cortecs_pointer_array_, TYPE)
+
+#define cortecs_array_forward_declare(TYPE) \
+    typedef struct cortecs_array_name(TYPE) cortecs_array_name(TYPE)
+
+#define cortecs_array_define(TYPE)    \
+    struct cortecs_array_name(TYPE) { \
+        uint32_t size;                \
+        TYPE elements[];              \
     }
 
 #define cortecs_array_declare(TYPE)      \

--- a/source/cortecs/gc/public-headers/cortecs/gc.h
+++ b/source/cortecs/gc/public-headers/cortecs/gc.h
@@ -1,17 +1,38 @@
 #ifndef CORTECS_GC_GC_H
 #define CORTECS_GC_GC_H
 
+#include <common.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef void (*cortecs_gc_finalizer)(void *allocation);
+#define CORTECS_GC_NO_FINALIZER 0
+#define CORTECS_GC_ALLOCATION 1
+
+typedef void (*cortecs_gc_finalizer_type)(void *allocation);
 typedef uint16_t cortecs_gc_finalizer_index;
 
-#define CORTECS_GC_NO_FINALIZER 0
+cortecs_gc_finalizer_index cortecs_gc_register_finalizer(cortecs_gc_finalizer_type finalizer, uint32_t size);
 
-void *cortecs_gc_alloc(uint32_t size_of_element, cortecs_gc_finalizer_index finalizer_index);
-void *cortecs_gc_alloc_array(uint32_t size_of_elements, uint32_t size_of_array, cortecs_gc_finalizer_index finalizer_index);
-cortecs_gc_finalizer_index cortecs_gc_register_finalizer(cortecs_gc_finalizer finalizer, uint32_t size);
+#define cortecs_gc_finalizer(TYPE) \
+    CONCAT(cortecs_gc_finalizer_, TYPE)
+
+#define cortecs_gc_finalizer_index_name(TYPE) \
+    CONCAT(cortecs_gc_finalizer(TYPE), _index)
+
+#define cortecs_gc_finalizer_declare(TYPE) \
+    cortecs_gc_finalizer_index cortecs_gc_finalizer_index_name(TYPE);
+
+#define cortecs_gc_finalizer_init(TYPE) \
+    cortecs_gc_finalizer_index_name(TYPE) = cortecs_gc_register_finalizer(cortecs_gc_finalizer(TYPE), sizeof(TYPE));
+
+void *cortecs_gc_alloc_impl(uint32_t size_of_type, cortecs_gc_finalizer_index finalizer_index);
+#define cortecs_gc_alloc(TYPE) \
+    cortecs_gc_alloc_impl(sizeof(TYPE), cortecs_gc_finalizer_index_name(TYPE))
+
+void *cortecs_gc_alloc_array_impl(uint32_t size_of_type, uint32_t size_of_array, uint32_t offset_of_elements, cortecs_gc_finalizer_index finalizer_index);
+#define cortecs_gc_alloc_array(TYPE, SIZE) \
+    cortecs_gc_alloc_array_impl(sizeof(TYPE), SIZE, offsetof(cortecs_array_name(TYPE), elements), cortecs_gc_finalizer_index_name(TYPE))
+
 void cortecs_gc_init();
 void cortecs_gc_inc(void *allocation);
 void cortecs_gc_dec(void *allocation);

--- a/source/cortecs/lsp/lsp.c
+++ b/source/cortecs/lsp/lsp.c
@@ -102,16 +102,8 @@ static cortecs_lsp_object accept_object(const cJSON *field) {
         size++;
     }
 
-    cortecs_array(cortecs_string) names = cortecs_gc_alloc_array(
-        sizeof(cortecs_string),
-        size,
-        CORTECS_GC_NO_FINALIZER
-    );
-    cortecs_array(cortecs_lsp_any) values = cortecs_gc_alloc_array(
-        sizeof(cortecs_lsp_any),
-        size,
-        CORTECS_GC_NO_FINALIZER
-    );
+    cortecs_array(cortecs_string) names = cortecs_gc_alloc_array(cortecs_string, size);
+    cortecs_array(cortecs_lsp_any) values = cortecs_gc_alloc_array(cortecs_lsp_any, size);
 
     // read all fields into the arrays
     uint32_t index = 0;
@@ -144,27 +136,19 @@ static cortecs_array(cortecs_lsp_any) accept_array(const cJSON *field) {
 
     if (field->child == NULL) {
         // array is empty: []
-        return cortecs_gc_alloc_array(
-            sizeof(cortecs_lsp_any),
-            0,
-            CORTECS_GC_NO_FINALIZER
-        );
+        return cortecs_gc_alloc_array(cortecs_lsp_any, 0);
     }
 
     cJSON *current = field->child;
 
-    // count length of array
-    uint32_t length = 0;
+    // count size of array
+    uint32_t size = 0;
     while (current != NULL) {
-        length++;
+        size++;
         current = current->next;
     }
 
-    cortecs_array(cortecs_lsp_any) elements = cortecs_gc_alloc_array(
-        sizeof(cortecs_lsp_any),
-        length,
-        CORTECS_GC_NO_FINALIZER
-    );
+    cortecs_array(cortecs_lsp_any) elements = cortecs_gc_alloc_array(cortecs_lsp_any, size);
 
     // read all fields into the array
     uint32_t index = 0;

--- a/source/cortecs/lsp/public-headers/cortecs/lsp.h
+++ b/source/cortecs/lsp/public-headers/cortecs/lsp.h
@@ -17,6 +17,7 @@ typedef struct {
 } cortecs_lsp_parse_error_t;
 
 typedef struct cortecs_lsp_any cortecs_lsp_any;
+extern cortecs_gc_finalizer_declare(cortecs_lsp_any);
 cortecs_array_forward_declare(cortecs_lsp_any);
 
 typedef struct {

--- a/source/cortecs/string/public-headers/cortecs/string.h
+++ b/source/cortecs/string/public-headers/cortecs/string.h
@@ -2,6 +2,7 @@
 #define CORTECS_STRING_STRING_H
 
 #include <cortecs/array.h>
+#include <cortecs/gc.h>
 #include <inttypes.h>
 #include <stdbool.h>
 
@@ -13,6 +14,7 @@ typedef struct {
     char content[];
 } cortecs_string_impl;
 typedef cortecs_string_impl *cortecs_string;
+extern cortecs_gc_finalizer_declare(cortecs_string);
 cortecs_array_declare(cortecs_string);
 
 cortecs_string cortecs_string_new(const char *format, ...);

--- a/source/cortecs/string/string.c
+++ b/source/cortecs/string/string.c
@@ -1,6 +1,7 @@
 #include <cortecs/gc.h>
 #include <cortecs/string.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,7 +33,7 @@ cortecs_string cortecs_string_new(const char *format, ...) {
     va_copy(args_out, args_size);
 
     // measure the output string
-    // there seems to be a bug in clang format that's false positive on this line
+    // there seems to be a bug in clang tidy that's false positive on this line
     int32_t size = vsnprintf(NULL, 0, format, args_size);  // NOLINT(clang-analyzer-valist.Uninitialized)
     if (size < 0) {
         // TODO encoding error. Have better error reporting
@@ -40,8 +41,8 @@ cortecs_string cortecs_string_new(const char *format, ...) {
     }
 
     // write the output string
-    cortecs_string out = cortecs_gc_alloc(
-        sizeof(uint32_t) + size + 1,
+    cortecs_string out = cortecs_gc_alloc_impl(
+        offsetof(cortecs_string_impl, content) + size + 1,
         CORTECS_GC_NO_FINALIZER
     );
     out->size = size;


### PR DESCRIPTION
C compilers use different amount of padding in the cortecs_array structs based on the alignment of the elements array type. calls to the gc array alloc need to account for this. We dont want users of the API to be concerned with this detail. This is a small redesign of the GC api to avoid users of the API from always having to submit finalizer and allocation details to the API while accounting for the varying alignment/padding