### PR TITLE
gc: fix incorrect offset when collecting arrays

### DIFF
--- a/source/cortecs/gc/public-headers/cortecs/gc.h
+++ b/source/cortecs/gc/public-headers/cortecs/gc.h
@@ -11,7 +11,7 @@
 typedef void (*cortecs_gc_finalizer_type)(void *allocation);
 typedef uint16_t cortecs_gc_finalizer_index;
 
-cortecs_gc_finalizer_index cortecs_gc_register_finalizer(cortecs_gc_finalizer_type finalizer, uint32_t size);
+cortecs_gc_finalizer_index cortecs_gc_register_finalizer(cortecs_gc_finalizer_type finalizer, uintptr_t size, uintptr_t offset_of_elements);
 
 #define cortecs_gc_finalizer(TYPE) \
     CONCAT(cortecs_gc_finalizer_, TYPE)
@@ -23,7 +23,7 @@ cortecs_gc_finalizer_index cortecs_gc_register_finalizer(cortecs_gc_finalizer_ty
     cortecs_gc_finalizer_index cortecs_gc_finalizer_index_name(TYPE);
 
 #define cortecs_gc_finalizer_init(TYPE) \
-    cortecs_gc_finalizer_index_name(TYPE) = cortecs_gc_register_finalizer(cortecs_gc_finalizer(TYPE), sizeof(TYPE));
+    cortecs_gc_finalizer_index_name(TYPE) = cortecs_gc_register_finalizer(cortecs_gc_finalizer(TYPE), sizeof(TYPE), offsetof(cortecs_array_name(TYPE), elements));
 
 void *cortecs_gc_alloc_impl(uint32_t size_of_type, cortecs_gc_finalizer_index finalizer_index);
 #define cortecs_gc_alloc(TYPE) \

--- a/test/cortecs/gc/test.c
+++ b/test/cortecs/gc/test.c
@@ -186,6 +186,7 @@ static void test_noop_finalizer_array() {
 typedef struct {
     void *target;
 } single_target;
+cortecs_array_declare(single_target);
 cortecs_gc_finalizer_declare(single_target);
 
 void cortecs_gc_finalizer(single_target)(void *allocation) {


### PR DESCRIPTION
Bug fix and API in PR #341 accounted for allocating arrays but forgot to address collecting arrays. Update gc to use correct offset to the first element of the array