### PR TITLE
gc: spoof allocation logging message during gc init

### DIFF
--- a/source/cortecs/log/log.c
+++ b/source/cortecs/log/log.c
@@ -1,10 +1,6 @@
 #include <cortecs/gc.h>
 #include <cortecs/log.h>
-#include <stdio.h>
 
-struct cortecs_log_stream {
-    FILE *log_file;
-};
 cortecs_array_declare(cortecs_log_stream);
 cortecs_finalizer_declare(cortecs_log_stream);
 void cortecs_finalizer(cortecs_log_stream)(void *allocation) {

--- a/source/cortecs/log/public-headers/cortecs/log.h
+++ b/source/cortecs/log/public-headers/cortecs/log.h
@@ -3,8 +3,13 @@
 
 #include <cJSON.h>
 #include <cortecs/string.h>
+#include <stdio.h>
 
 typedef struct cortecs_log_stream *cortecs_log_stream;
+struct cortecs_log_stream {
+    FILE *log_file;
+};
+extern cortecs_finalizer_declare(cortecs_log_stream);
 
 void cortecs_log_init();
 cortecs_log_stream cortecs_log_open(cortecs_string path);

--- a/test/cortecs/gc/test.c
+++ b/test/cortecs/gc/test.c
@@ -2,6 +2,7 @@
 #include <cortecs/array.h>
 #include <cortecs/finalizer.h>
 #include <cortecs/gc.h>
+#include <cortecs/log.h>
 #include <cortecs/world.h>
 #include <flecs.h>
 #include <stdbool.h>
@@ -305,8 +306,29 @@ static void test_n_recursive_collect() {
     cortecs_world_cleanup();
 }
 
+static void test_gc_log_open_close() {
+    const char *log_path = "./test_gc_log_open_close.log";
+    cortecs_world_init();
+    cortecs_finalizer_init();
+    cortecs_log_init();
+    cortecs_gc_init(log_path);
+    cortecs_gc_cleanup();
+    cortecs_world_cleanup();
+
+    FILE *log = fopen(log_path, "r");
+    char line[2048];
+    while (fgets(line, sizeof(line), log)) {
+        printf("%s", line);
+    }
+    fclose(log);
+
+    remove(log_path);
+}
+
 int main() {
     UNITY_BEGIN();
+
+    RUN_TEST(test_gc_log_open_close);
 
     RUN_TEST(test_collect_unused_allocation);
     RUN_TEST(test_collect_unused_allocation_array);


### PR DESCRIPTION
A couple of GC logging messages get lost during initialization because of circular dependencies between the log being initialized to be able to log, but the GC being already initialized to be able to allocate the log. This leads to 2 alloc log messages and 2 enqueue_dec log messages being lost. Spoof these messages for log completeness