### PR TITLE
build: update BUILD files

### DIFF
--- a/source/cortecs/array/BUILD
+++ b/source/cortecs/array/BUILD
@@ -1,7 +1,6 @@
 cc_library(
     name = "array",
-    srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]) + glob(["public-headers/cortecs/*.h"]),
+    hdrs = glob(["public-headers/cortecs/*.h"]),
     features = ["treat_warnings_as_errors"],
     includes = ["public-headers/"],
     visibility = ["//visibility:public"],

--- a/source/cortecs/finalizer/BUILD
+++ b/source/cortecs/finalizer/BUILD
@@ -1,7 +1,7 @@
 cc_library(
     name = "finalizer",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]) + glob(["public-headers/cortecs/*.h"]),
+    hdrs = glob(["public-headers/cortecs/*.h"]),
     features = ["treat_warnings_as_errors"],
     includes = ["public-headers/"],
     visibility = ["//visibility:public"],

--- a/source/cortecs/gc/BUILD
+++ b/source/cortecs/gc/BUILD
@@ -67,7 +67,6 @@ cc_library(
 cc_library(
     name = "sources",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]),
     features = ["treat_warnings_as_errors"],
     visibility = [
         "//source/cortecs/log:__subpackages__",

--- a/source/cortecs/lexer/BUILD
+++ b/source/cortecs/lexer/BUILD
@@ -1,7 +1,7 @@
 cc_library(
     name = "lexer",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]) + glob(["public-headers/cortecs/*.h"]),
+    hdrs = glob(["public-headers/cortecs/*.h"]),
     features = ["treat_warnings_as_errors"],
     includes = ["public-headers/"],
     visibility = ["//visibility:public"],

--- a/source/cortecs/log/BUILD
+++ b/source/cortecs/log/BUILD
@@ -20,7 +20,6 @@ cc_library(
 cc_library(
     name = "sources",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]),
     features = ["treat_warnings_as_errors"],
     visibility = [
         "//source/cortecs/gc:__subpackages__",

--- a/source/cortecs/lsp/BUILD
+++ b/source/cortecs/lsp/BUILD
@@ -1,7 +1,7 @@
 cc_library(
     name = "lsp",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]) + glob(["public-headers/cortecs/*.h"]),
+    hdrs = glob(["public-headers/cortecs/*.h"]),
     features = ["treat_warnings_as_errors"],
     includes = ["public-headers/"],
     visibility = ["//visibility:public"],

--- a/source/cortecs/parser/BUILD
+++ b/source/cortecs/parser/BUILD
@@ -1,7 +1,7 @@
 cc_library(
     name = "parser",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]) + glob(["public-headers/cortecs/*.h"]),
+    hdrs = glob(["public-headers/cortecs/*.h"]),
     features = ["treat_warnings_as_errors"],
     includes = ["public-headers/"],
     visibility = ["//visibility:public"],

--- a/source/cortecs/string/BUILD
+++ b/source/cortecs/string/BUILD
@@ -19,7 +19,6 @@ cc_library(
 cc_library(
     name = "sources",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]),
     features = ["treat_warnings_as_errors"],
     visibility = [
         "//source/cortecs/gc:__subpackages__",

--- a/source/cortecs/world/BUILD
+++ b/source/cortecs/world/BUILD
@@ -1,7 +1,7 @@
 cc_library(
     name = "world",
     srcs = glob(["*.c"]),
-    hdrs = glob(["*.h"]) + glob(["public-headers/cortecs/*.h"]),
+    hdrs = glob(["public-headers/cortecs/*.h"]),
     features = ["treat_warnings_as_errors"],
     includes = ["public-headers/"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
In bazel, srcs is for both sources and private headers. hdrs is for only public headers. Also glob can take multiple strings in the list rather than adding multiple globs together