### PR TITLE
gc: Fix NULL handling in gc inc/dec

### DIFF
--- a/source/cortecs/gc/gc.c
+++ b/source/cortecs/gc/gc.c
@@ -286,6 +286,10 @@ void cortecs_gc_dec_impl(
     const char *function,
     int line
 ) {
+    if (allocation == NULL) {
+        return;
+    }
+
     if (ecs_is_deferred(world)) {
         // a system is running.
         // Defer the decrement until after system logic completes
@@ -306,6 +310,10 @@ void cortecs_gc_inc_impl(
     const char *function,
     int line
 ) {
+    if (allocation == NULL) {
+        return;
+    }
+
     gc_header *header = get_header(allocation);
 
     if (log_stream != NULL) {

--- a/test/cortecs/gc/test.c
+++ b/test/cortecs/gc/test.c
@@ -325,11 +325,22 @@ static void test_gc_log_open_close() {
     remove(log_path);
 }
 
+static void test_inc_dec_null() {
+    cortecs_world_init();
+    cortecs_finalizer_init();
+    cortecs_gc_init(NULL);
+
+    cortecs_gc_inc(NULL);
+    cortecs_gc_dec(NULL);
+
+    cortecs_world_cleanup();
+}
+
 int main() {
     UNITY_BEGIN();
 
     RUN_TEST(test_gc_log_open_close);
-
+    RUN_TEST(test_inc_dec_null);
     RUN_TEST(test_collect_unused_allocation);
     RUN_TEST(test_collect_unused_allocation_array);
     RUN_TEST(test_keep_used_allocation);


### PR DESCRIPTION
This pull request fixes an issue where NULL was being passed to the gc inc/dec functions. The code now checks for NULL and returns early if NULL is passed as an argument. Additionally, a new test case has been added to ensure that the inc/dec functions handle NULL correctly.